### PR TITLE
Fixed crash caused by decodedImage in CCBufferedImageView being nil.

### DIFF
--- a/Code/CCBufferedImageView.swift
+++ b/Code/CCBufferedImageView.swift
@@ -64,8 +64,11 @@ public class CCBufferedImageView : UIImageView, NSURLConnectionDataDelegate {
         dispatch_sync(queue) {
             let decoder = CCBufferedImageDecoder(data: self.data)
             decoder.decompress()
-            let decodedImage = decoder.toImage()
-
+            
+            guard let decodedImage = decoder.toImage() else {
+                return
+            }
+            
             UIGraphicsBeginImageContext(CGSizeMake(1,1))
             let context = UIGraphicsGetCurrentContext()
             CGContextDrawImage(context, CGRectMake(0, 0, 1, 1), decodedImage.CGImage)


### PR DESCRIPTION
I've noticed that occasionally I get a crash when using CCBufferedImageView with progressive JPEGs. The crash is an EXC_BAD_ACCESS on the decodedImage variable in ` public func connection(connection: NSURLConnection, didReceiveData data: NSData) `.

This crash is quite easily reproducible if you place the CCBufferedImageView inside a tableview cell.

Adding a guard to make sure that decodedImage is not nil solves the issue.